### PR TITLE
Added support for enabling SSL in the Seq Email app.

### DIFF
--- a/src/Seq.App.Email/EmailReactor.cs
+++ b/src/Seq.App.Email/EmailReactor.cs
@@ -39,6 +39,12 @@ namespace Seq.App.Email
 
         [SeqAppSetting(
             IsOptional = true,
+            DisplayName = "Enable SSL",
+            HelpText = "Check this box if SSL is required to send email messages.")]
+        public bool? EnableSsl { get; set; }
+
+        [SeqAppSetting(
+            IsOptional = true,
             InputType = SettingInputType.LongText,
             DisplayName = "Body template",
             HelpText = "The template to use when generating the email body. You can use Mustache-style {{PropertyName}} syntax " + 
@@ -74,6 +80,11 @@ namespace Seq.App.Email
             var client = new SmtpClient(Host, Port ?? 25);
             if (!string.IsNullOrWhiteSpace(Username))
                 client.Credentials = new NetworkCredential(Username, Password);
+
+            if (EnableSsl.HasValue)
+            {
+                client.EnableSsl = EnableSsl.Value;
+            }
 
             var message = new MailMessage(From, To, subject, body);
             if (IsBodyHtml == true && !string.IsNullOrWhiteSpace(BodyTemplate))


### PR DESCRIPTION
Hello!

I've added support for enabling SSL in the Seq Email application.

Not sure if you accept PRs on these applications or if I added the property in the correct way.

I also couldn't determine an appropriate way to test this, so let me know if there are some steps I can take to test this change.

Feel free to edit the prop name/help text if you think of something friendlier.

Thanks!
