### PR TITLE
Implement batching of emails

### DIFF
--- a/seq-apps.sln
+++ b/seq-apps.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.FirstOfType", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.EmailPlus", "src\Seq.App.EmailPlus\Seq.App.EmailPlus.csproj", "{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.EmailPlus.Tests", "test\Seq.App.EmailPlus.Tests\Seq.App.EmailPlus.Tests.csproj", "{756873CC-1042-4D7F-BBE0-8FBD3107F311}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{756873CC-1042-4D7F-BBE0-8FBD3107F311}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{756873CC-1042-4D7F-BBE0-8FBD3107F311}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{756873CC-1042-4D7F-BBE0-8FBD3107F311}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{756873CC-1042-4D7F-BBE0-8FBD3107F311}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,5 +78,6 @@ Global
 		{47DBBC2D-0EF4-415C-B65C-B0779B0D534B} = {3FC57D53-9F60-4FAB-AFD8-8CB23EE3B9D9}
 		{BBF8EFB1-BAEA-40A8-A7AC-30C81C45FEA0} = {3FC57D53-9F60-4FAB-AFD8-8CB23EE3B9D9}
 		{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9} = {3FC57D53-9F60-4FAB-AFD8-8CB23EE3B9D9}
+		{756873CC-1042-4D7F-BBE0-8FBD3107F311} = {775EF423-0A25-485A-BFA0-BAE59F580C9A}
 	EndGlobalSection
 EndGlobal

--- a/src/Seq.App.EmailPlus/BatchingStream.cs
+++ b/src/Seq.App.EmailPlus/BatchingStream.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 namespace Seq.App.EmailPlus
 {
-    public class BatchingStream<TKey,TValue> : IBatchingStream<TValue>
+    public class BatchingStream<TKey, TValue> : IBatchingStream<TValue>
     {
-        private readonly Func<TValue, TKey> _keySelector;
-        private readonly IScheduler _scheduler;
         private readonly TimeSpan? _delay;
+        private readonly Func<TValue, TKey> _keySelector;
         private readonly TimeSpan? _maxDelay;
         private readonly int? _maxSize;
+        private readonly IScheduler _scheduler;
         private readonly Subject<TValue> _stream;
 
         public BatchingStream(Func<TValue, TKey> keySelector, IScheduler scheduler, TimeSpan? delay = null, TimeSpan? maxDelay = null, int? maxSize = null)
@@ -37,40 +36,25 @@ namespace Seq.App.EmailPlus
             {
                 var grouped = _stream.GroupByUntil(v => _keySelector(v), group =>
                 {
-                    Debug.WriteLine("[{0:O}] Starting group with key [{1}].", _scheduler.Now, group.Key);
-
                     // Convert source to IObservable<long> so it can be merged with Observable<Timer> below.
                     // The particular value has no effect, it is just a signal.
                     var duration = group.Select(v => default(long));
 
-                    if (_delay.HasValue)
-                    {
-                        Debug.WriteLine("Batch throttle of [{0}]s set for group with key [{1}].", _delay.Value.TotalSeconds, group.Key);
-                        duration = duration.Throttle(_delay.Value, _scheduler);
+                    if (!_delay.HasValue)
+                        return duration.Take(1);
 
-                        if (_maxSize.HasValue)
-                        {
-                            Debug.WriteLine("Batch limit of [{0}] items set for group with key [{1}].", _maxSize.Value, group.Key);
-                            duration = group.Select(v => default(long)).Skip(_maxSize.Value - 1).Merge(duration);
-                        }
+                    duration = duration.Throttle(_delay.Value, _scheduler);
 
-                        if (_maxDelay.HasValue)
-                        {
-                            Debug.WriteLine("Batch timeout of [{0}]s set for group with key [{1}].", _maxDelay.Value.TotalSeconds, group.Key);
-                            duration = duration.Merge(Observable.Timer(_maxDelay.Value, _scheduler));
-                        }
-                    }
-                    else
-                    {
-                        Debug.WriteLine("Batch limit of [1] item set for group with key [{0}].", group.Key);
-                    }
+                    if (_maxSize.HasValue)
+                        duration = @group.Select(v => default(long)).Skip(_maxSize.Value - 1).Merge(duration);
 
-                    return duration.Take(1).Do(_ => Debug.WriteLine("[{0:O}] Ending group [{1}].", _scheduler.Now, group.Key));
+                    if (_maxDelay.HasValue)
+                        duration = duration.Merge(Observable.Timer(_maxDelay.Value, _scheduler));
+
+                    return duration.Take(1);
                 });
 
-                return grouped.SelectMany(g => g.ToList(), (o, list) => { Debug.WriteLine("[{0:O}] Emitting group of size [{1}].", _scheduler.Now, list.Count);
-                                                                            return list;
-                });
+                return grouped.SelectMany(g => g.ToList(), (o, list) => list);
             }
         }
     }

--- a/src/Seq.App.EmailPlus/BatchingStream.cs
+++ b/src/Seq.App.EmailPlus/BatchingStream.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Seq.App.EmailPlus
+{
+    public class BatchingStream<TKey,TValue> : IBatchingStream<TValue>
+    {
+        private readonly Func<TValue, TKey> _keySelector;
+        private readonly IScheduler _scheduler;
+        private readonly TimeSpan? _delay;
+        private readonly TimeSpan? _maxDelay;
+        private readonly int? _maxSize;
+        private readonly Subject<TValue> _stream;
+
+        public BatchingStream(Func<TValue, TKey> keySelector, IScheduler scheduler, TimeSpan? delay = null, TimeSpan? maxDelay = null, int? maxSize = null)
+        {
+            _keySelector = keySelector;
+            _scheduler = scheduler;
+            _delay = delay;
+            _maxDelay = maxDelay;
+            _maxSize = maxSize;
+            _stream = new Subject<TValue>();
+        }
+
+        public void Add(TValue value)
+        {
+            _stream.OnNext(value);
+        }
+
+        public IObservable<IList<TValue>> Batches
+        {
+            get
+            {
+                var grouped = _stream.GroupByUntil(v => _keySelector(v), group =>
+                {
+                    Debug.WriteLine("[{0:O}] Starting group with key [{1}].", _scheduler.Now, group.Key);
+
+                    // Convert source to IObservable<long> so it can be merged with Observable<Timer> below.
+                    // The particular value has no effect, it is just a signal.
+                    var duration = group.Select(v => default(long));
+
+                    if (_delay.HasValue)
+                    {
+                        Debug.WriteLine("Batch throttle of [{0}]s set for group with key [{1}].", _delay.Value.TotalSeconds, group.Key);
+                        duration = duration.Throttle(_delay.Value, _scheduler);
+
+                        if (_maxSize.HasValue)
+                        {
+                            Debug.WriteLine("Batch limit of [{0}] items set for group with key [{1}].", _maxSize.Value, group.Key);
+                            duration = group.Select(v => default(long)).Skip(_maxSize.Value - 1).Merge(duration);
+                        }
+
+                        if (_maxDelay.HasValue)
+                        {
+                            Debug.WriteLine("Batch timeout of [{0}]s set for group with key [{1}].", _maxDelay.Value.TotalSeconds, group.Key);
+                            duration = duration.Merge(Observable.Timer(_maxDelay.Value, _scheduler));
+                        }
+                    }
+                    else
+                    {
+                        Debug.WriteLine("Batch limit of [1] item set for group with key [{0}].", group.Key);
+                    }
+
+                    return duration.Take(1).Do(_ => Debug.WriteLine("[{0:O}] Ending group [{1}].", _scheduler.Now, group.Key));
+                });
+
+                return grouped.SelectMany(g => g.ToList(), (o, list) => { Debug.WriteLine("[{0:O}] Emitting group of size [{1}].", _scheduler.Now, list.Count);
+                                                                            return list;
+                });
+            }
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/BatchingStreamFactory.cs
+++ b/src/Seq.App.EmailPlus/BatchingStreamFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Reactive.Concurrency;
+
+namespace Seq.App.EmailPlus
+{
+    public class BatchingStreamFactory<TKey, TValue> : IBatchingStreamFactory<TKey, TValue>
+    {
+        public IBatchingStream<TValue> Create(Func<TValue, TKey> keySelector, IScheduler scheduler, TimeSpan? delay, TimeSpan? maxDelay, int? maxSize)
+        {
+            return new BatchingStream<TKey, TValue>(keySelector, scheduler, delay, maxDelay, maxSize);
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/EmailFormatter.cs
+++ b/src/Seq.App.EmailPlus/EmailFormatter.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
+using System.Linq;
+using Handlebars;
+using Newtonsoft.Json;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.EmailPlus
+{
+    public class EmailFormatter : IEmailFormatter
+    {
+        private readonly string _instanceName;
+        private readonly string _serverUri;
+        private readonly int? _maxSubjectLength;
+        private readonly Func<object,string> _subjectTemplate;
+        private readonly Func<object,string> _bodyTemplate;
+        const string DefaultSubjectTemplate = @"[{{$Events.[0].$Level}}] {{{$Events.[0].$Message}}} (via Seq){{#if $MultipleEvents}} ({{$EventCount}}){{/if}}";
+
+        public EmailFormatter(string instanceName, string serverUri, string bodyTemplate = null, string subjectTemplate = null, int? maxSubjectLength = null)
+        {
+            _instanceName = instanceName;
+            _serverUri = serverUri;
+            _maxSubjectLength = maxSubjectLength;
+            Handlebars.Handlebars.RegisterHelper("pretty", PrettyPrint);
+
+            _subjectTemplate = Handlebars.Handlebars.Compile(string.IsNullOrWhiteSpace(subjectTemplate) ? DefaultSubjectTemplate : subjectTemplate);
+            _bodyTemplate = Handlebars.Handlebars.Compile(string.IsNullOrWhiteSpace(bodyTemplate) ? Resources.DefaultBodyTemplate : bodyTemplate);
+        }
+
+        public string FormatSubject(ICollection<Event<LogEventData>> events)
+        {
+            var subject = FormatTemplate(_subjectTemplate, events).Trim().Replace("\r", "").Replace("\n", "");
+            return _maxSubjectLength.HasValue ? subject.Substring(0, _maxSubjectLength.Value) : subject;
+        }
+
+        public string FormatBody(ICollection<Event<LogEventData>> events)
+        {
+            return FormatTemplate(_bodyTemplate, events);
+        }
+
+        string FormatTemplate(Func<object, string> template, ICollection<Event<LogEventData>> events)
+        {
+            var payload = ToDynamic(new Dictionary<string, object>
+            {
+                {"$Instance", _instanceName},
+                {"$ServerUri", _serverUri},
+                {"$MultipleEvents", events.Count > 1},
+                {"$EventCount", events.Count},
+                {
+                    "$Events", events.Select(evt => new Dictionary<string, object>
+                    {
+                        {"$Id", evt.Id},
+                        {"$UtcTimestamp", evt.TimestampUtc},
+                        {"$LocalTimestamp", evt.Data.LocalTimestamp},
+                        {"$Level", evt.Data.Level},
+                        {"$MessageTemplate", evt.Data.MessageTemplate},
+                        {"$Message", evt.Data.RenderedMessage},
+                        {"$Exception", evt.Data.Exception},
+                        {"$Properties", ToDynamic(evt.Data.Properties)},
+                        {"$EventType", "$" + evt.EventType.ToString("X8")}
+                    })
+                }
+            });
+
+            return template(payload);
+        }
+
+        static void PrettyPrint(TextWriter output, object context, object[] arguments)
+        {
+            var value = arguments.FirstOrDefault();
+            if (value == null)
+                output.WriteSafeString("null");
+            else if (value is IEnumerable<object> || value is IEnumerable<KeyValuePair<string, object>>)
+                output.WriteSafeString(JsonConvert.SerializeObject(FromDynamic(value)));
+            else
+                output.WriteSafeString(value.ToString());
+        }
+
+        static object FromDynamic(object o)
+        {
+            var dictionary = o as IEnumerable<KeyValuePair<string, object>>;
+            if (dictionary != null)
+            {
+                return dictionary.ToDictionary(kvp => kvp.Key, kvp => FromDynamic(kvp.Value));
+            }
+
+            var enumerable = o as IEnumerable<object>;
+            if (enumerable != null)
+            {
+                return enumerable.Select(FromDynamic).ToArray();
+            }
+
+            return o;
+        }
+
+        static object ToDynamic(object o)
+        {
+            var dictionary = o as IEnumerable<KeyValuePair<string, object>>;
+            if (dictionary != null)
+            {
+                var result = new ExpandoObject();
+                var asDict = (IDictionary<string, object>)result;
+                foreach (var kvp in dictionary)
+                    asDict.Add(kvp.Key, ToDynamic(kvp.Value));
+                return result;
+            }
+
+            var enumerable = o as IEnumerable<object>;
+            if (enumerable != null)
+            {
+                return enumerable.Select(ToDynamic).ToArray();
+            }
+
+            return o;
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/EmailFormatter.cs
+++ b/src/Seq.App.EmailPlus/EmailFormatter.cs
@@ -12,12 +12,14 @@ namespace Seq.App.EmailPlus
 {
     public class EmailFormatter : IEmailFormatter
     {
+        private const string DefaultSubjectTemplate =
+            @"[{{$Events.[0].$Level}}] {{{$Events.[0].$Message}}} (via Seq){{#if $MultipleEvents}} ({{$EventCount}}){{/if}}";
+
+        private readonly Func<object, string> _bodyTemplate;
         private readonly string _instanceName;
-        private readonly string _serverUri;
         private readonly int? _maxSubjectLength;
-        private readonly Func<object,string> _subjectTemplate;
-        private readonly Func<object,string> _bodyTemplate;
-        const string DefaultSubjectTemplate = @"[{{$Events.[0].$Level}}] {{{$Events.[0].$Message}}} (via Seq){{#if $MultipleEvents}} ({{$EventCount}}){{/if}}";
+        private readonly string _serverUri;
+        private readonly Func<object, string> _subjectTemplate;
 
         public EmailFormatter(string instanceName, string serverUri, string bodyTemplate = null, string subjectTemplate = null, int? maxSubjectLength = null)
         {
@@ -41,7 +43,7 @@ namespace Seq.App.EmailPlus
             return FormatTemplate(_bodyTemplate, events);
         }
 
-        string FormatTemplate(Func<object, string> template, ICollection<Event<LogEventData>> events)
+        private string FormatTemplate(Func<object, string> template, ICollection<Event<LogEventData>> events)
         {
             var payload = ToDynamic(new Dictionary<string, object>
             {
@@ -68,7 +70,7 @@ namespace Seq.App.EmailPlus
             return template(payload);
         }
 
-        static void PrettyPrint(TextWriter output, object context, object[] arguments)
+        private static void PrettyPrint(TextWriter output, object context, object[] arguments)
         {
             var value = arguments.FirstOrDefault();
             if (value == null)
@@ -79,7 +81,7 @@ namespace Seq.App.EmailPlus
                 output.WriteSafeString(value.ToString());
         }
 
-        static object FromDynamic(object o)
+        private static object FromDynamic(object o)
         {
             var dictionary = o as IEnumerable<KeyValuePair<string, object>>;
             if (dictionary != null)
@@ -96,13 +98,13 @@ namespace Seq.App.EmailPlus
             return o;
         }
 
-        static object ToDynamic(object o)
+        private static object ToDynamic(object o)
         {
             var dictionary = o as IEnumerable<KeyValuePair<string, object>>;
             if (dictionary != null)
             {
                 var result = new ExpandoObject();
-                var asDict = (IDictionary<string, object>)result;
+                var asDict = (IDictionary<string, object>) result;
                 foreach (var kvp in dictionary)
                     asDict.Add(kvp.Key, ToDynamic(kvp.Value));
                 return result;

--- a/src/Seq.App.EmailPlus/EmailFormatter.cs
+++ b/src/Seq.App.EmailPlus/EmailFormatter.cs
@@ -33,7 +33,7 @@ namespace Seq.App.EmailPlus
         public string FormatSubject(ICollection<Event<LogEventData>> events)
         {
             var subject = FormatTemplate(_subjectTemplate, events).Trim().Replace("\r", "").Replace("\n", "");
-            return _maxSubjectLength.HasValue ? subject.Substring(0, _maxSubjectLength.Value) : subject;
+            return _maxSubjectLength.HasValue && subject.Length > _maxSubjectLength.Value ? subject.Substring(0, _maxSubjectLength.Value) : subject;
         }
 
         public string FormatBody(ICollection<Event<LogEventData>> events)

--- a/src/Seq.App.EmailPlus/EmailFormatterFactory.cs
+++ b/src/Seq.App.EmailPlus/EmailFormatterFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public class EmailFormatterFactory : IEmailFormatterFactory
+    {
+        public IEmailFormatter Create(string instanceName, string serverUri, string bodyTemplate, string subjectTemplate, int? maxSubjectLength)
+        {
+            return new EmailFormatter(instanceName, serverUri, bodyTemplate, subjectTemplate, maxSubjectLength);
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -129,7 +129,14 @@ namespace Seq.App.EmailPlus
                 if (!string.IsNullOrWhiteSpace(Username))
                     client.Credentials = new NetworkCredential(Username, Password);
 
-                client.Send(BuildMessage(events));
+                try
+                {
+                    client.Send(BuildMessage(events));
+                }
+                catch (SmtpException ex)
+                {
+                    Log.Warning(ex, "Exception while sending email.");
+                }
             }
         }
 

--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -10,7 +10,7 @@ using Seq.Apps.LogEvents;
 
 namespace Seq.App.EmailPlus
 {
-    [SeqApp("Email+", Description = "Uses a Handlebars template to send events as SMTP email, optionally batching multiple events into single messages.")]
+    [SeqApp("Email+", Description = "Uses a Handlebars template to send events as SMTP email.")]
     public class EmailReactor : Reactor, ISubscribeTo<LogEventData>
     {
         private readonly IScheduler _scheduler;

--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -22,12 +22,16 @@ namespace Seq.App.EmailPlus
         IBatchingStream<Event<LogEventData>> _eventStream;
         int? _maxSubjectLength = 130;
 
+        public EmailReactor()
+            : this(new SmtpMailClientFactory(), new EmailFormatterFactory(), new BatchingStreamFactory<string, Event<LogEventData>>(), Scheduler.Default)
+        {}
+
         public EmailReactor(IMailClientFactory mailClientFactory = null, IEmailFormatterFactory emailFormatterFactory = null, IBatchingStreamFactory<string,Event<LogEventData>> batchingStreamFactory = null, IScheduler scheduler = null)
         {
+            _mailClientFactory = mailClientFactory;
+            _emailFormatterFactory = emailFormatterFactory;
+            _eventStreamFactory = batchingStreamFactory;
             _scheduler = scheduler;
-            _mailClientFactory = mailClientFactory ?? new SmtpMailClientFactory();
-            _emailFormatterFactory = emailFormatterFactory ?? new EmailFormatterFactory();
-            _eventStreamFactory = batchingStreamFactory ?? new BatchingStreamFactory<string, Event<LogEventData>>();
         }
 
         [SeqAppSetting(

--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -134,7 +134,7 @@ namespace Seq.App.EmailPlus
 
         MailMessage BuildMessage(ICollection<Event<LogEventData>> events)
         {
-            return new MailMessage(From, To) {Subject = _formatter.FormatSubject(events), Body = _formatter.FormatBody(events)};
+            return new MailMessage(From, To) {Subject = _formatter.FormatSubject(events), Body = _formatter.FormatBody(events), IsBodyHtml = true};
         }
     }
 }

--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -20,7 +20,7 @@ namespace Seq.App.EmailPlus
         
         IEmailFormatter _formatter;
         IBatchingStream<Event<LogEventData>> _eventStream;
-        int? _maxSubjectLength = 130;
+        const int MaxSubjectLength = 130;
 
         public EmailReactor()
             : this(new SmtpMailClientFactory(), new EmailFormatterFactory(), new BatchingStreamFactory<string, Event<LogEventData>>(), Scheduler.Default)
@@ -49,16 +49,6 @@ namespace Seq.App.EmailPlus
             DisplayName = "Subject template",
             HelpText = "The subject of the email, using Handlebars syntax. If blank, a default subject will be generated.")]
         public string SubjectTemplate { get; set; }
-
-        [SeqAppSetting(
-            IsOptional = true,
-            DisplayName = "Max subject length",
-            HelpText = "Limits the length of email subjects.")]
-        public int? MaxSubjectLength
-        {
-            get { return _maxSubjectLength; }
-            set { _maxSubjectLength = value; }
-        }
 
         [SeqAppSetting(
             HelpText = "The name of the SMTP server machine.")]

--- a/src/Seq.App.EmailPlus/IBatchingStream.cs
+++ b/src/Seq.App.EmailPlus/IBatchingStream.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Seq.App.EmailPlus
+{
+    public interface IBatchingStream<TValue>
+    {
+        void Add(TValue value);
+        IObservable<IList<TValue>> Batches { get; }
+    }
+}

--- a/src/Seq.App.EmailPlus/IBatchingStream.cs
+++ b/src/Seq.App.EmailPlus/IBatchingStream.cs
@@ -5,7 +5,7 @@ namespace Seq.App.EmailPlus
 {
     public interface IBatchingStream<TValue>
     {
-        void Add(TValue value);
         IObservable<IList<TValue>> Batches { get; }
+        void Add(TValue value);
     }
 }

--- a/src/Seq.App.EmailPlus/IBatchingStreamFactory.cs
+++ b/src/Seq.App.EmailPlus/IBatchingStreamFactory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Reactive.Concurrency;
+
+namespace Seq.App.EmailPlus
+{
+    public interface IBatchingStreamFactory<in TKey, TValue>
+    {
+        IBatchingStream<TValue> Create(
+            Func<TValue, TKey> keySelector, IScheduler scheduler, TimeSpan? delay, TimeSpan? maxDelay, int? maxSize);
+    }
+}

--- a/src/Seq.App.EmailPlus/IEmailFormatter.cs
+++ b/src/Seq.App.EmailPlus/IEmailFormatter.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.EmailPlus
+{
+    public interface IEmailFormatter
+    {
+        string FormatSubject(ICollection<Event<LogEventData>> events);
+        string FormatBody(ICollection<Event<LogEventData>> events);
+    }
+}

--- a/src/Seq.App.EmailPlus/IEmailFormatterFactory.cs
+++ b/src/Seq.App.EmailPlus/IEmailFormatterFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public interface IEmailFormatterFactory
+    {
+        IEmailFormatter Create(string instanceName, string serverUri, string bodyTemplate, string subjectTemplate, int? maxSubjectLength);
+    }
+}

--- a/src/Seq.App.EmailPlus/IMailClient.cs
+++ b/src/Seq.App.EmailPlus/IMailClient.cs
@@ -7,13 +7,9 @@ namespace Seq.App.EmailPlus
     public interface IMailClient : IDisposable
     {
         ICredentialsByHost Credentials { get; set; }
-
         bool EnableSsl { get; set; }
-
         string Host { get; set; }
-
         int Port { get; set; }
-
         void Send(MailMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/IMailClient.cs
+++ b/src/Seq.App.EmailPlus/IMailClient.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Net;
+using System.Net.Mail;
+
+namespace Seq.App.EmailPlus
+{
+    public interface IMailClient : IDisposable
+    {
+        ICredentialsByHost Credentials { get; set; }
+
+        bool EnableSsl { get; set; }
+
+        string Host { get; set; }
+
+        int Port { get; set; }
+
+        void Send(MailMessage message);
+    }
+}

--- a/src/Seq.App.EmailPlus/IMailClientFactory.cs
+++ b/src/Seq.App.EmailPlus/IMailClientFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public interface IMailClientFactory
+    {
+        IMailClient Create(string host, int port, bool enableSsl);
+    }
+}

--- a/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <title>[{{$Level}}] {{$Message}} (via Seq)</title>
+    <title>[{{$Events.[0].$Level}}] {{{$Events.[0].$Message}}} (via Seq){{#if $MultipleEvents}} ({{$EventCount}}){{/if}}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <style>
         .email-body {
@@ -126,35 +126,37 @@
     </style>
 </head>
 <body>
-    <div class="email-body" style="margin-top:10px;margin-bottom:10px;margin-right:10px;margin-left:10px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;color:#333;background-color:#fff;">
-        <div class="seq-event-detail" style="width:100%;padding-top:0;padding-bottom:2px;padding-right:2px;padding-left:2px;margin-top:2px;margin-bottom:0;margin-right:-3px;margin-left:-3px;overflow:visible;white-space:nowrap;border-style:solid;border-width:1px;border-radius:2px;background-color:#eff9ff;border-color:#54afcc;">
-            <div class="seq-event-tools" style="float:left;margin-right:5px;">
-                <span class="seq-event-timestamp" title="{{$UtcTimestamp}}" style="margin-right:5px;color:white;"><span class="datetime" style="display:inline-block;width:172px;padding-top:2px;padding-bottom:2px;padding-right:4px;padding-left:4px;font-size:11.844px;font-weight:bold;line-height:14px;color:#fff;text-shadow:none;white-space:nowrap;vertical-align:baseline;background-color:#aaa;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:2px;margin-top:2px;">{{$LocalTimestamp}}</span></span>
+    {{#each Events}}
+    <div class="email-body" style="margin-top: 10px; margin-bottom: 10px; margin-right: 10px; margin-left: 10px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333; background-color: #fff;">
+        <div class="seq-event-detail" style="width: 100%; padding-top: 0; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 2px; margin-bottom: 0; margin-right: -3px; margin-left: -3px; overflow: visible; white-space: nowrap; border-style: solid; border-width: 1px; border-radius: 2px; background-color: #eff9ff; border-color: #54afcc;">
+            <div class="seq-event-tools" style="float: left; margin-right: 5px;">
+                <span class="seq-event-timestamp" title="{{$UtcTimestamp}}" style="margin-right: 5px; color: white;"><span class="datetime" style="display: inline-block; width: 172px; padding-top: 2px; padding-bottom: 2px; padding-right: 4px; padding-left: 4px; font-size: 11.844px; font-weight: bold; line-height: 14px; color: #fff; text-shadow: none; white-space: nowrap; vertical-align: baseline; background-color: #aaa; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 2px; margin-top: 2px;">{{$LocalTimestamp}}</span></span>
             </div>
-            <div class="seq-event-data" style="margin-top:2px;margin-left:190px;overflow:visible;white-space:normal;">
+            <div class="seq-event-data" style="margin-top: 2px; margin-left: 190px; overflow: visible; white-space: normal;">
                 <div>
                     <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
                 </div>
-                <div class="seq-event-actions" style="margin-top:5px;">
-                    <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action" style="color:#007acc;text-decoration:none;padding-right:10px;font-size:12px;">View in Seq</a>
+                <div class="seq-event-actions" style="margin-top: 5px;">
+                    <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action" style="color: #007acc; text-decoration: none; padding-right: 10px; font-size: 12px;">View in Seq</a>
                 </div>
-                <div class="seq-event-properties" style="margin-top:5px;">
+                <div class="seq-event-properties" style="margin-top: 5px;">
                     {{#each $Properties}}
                     <div class="seq-event-property">
-                        <div class="seq-property-name" title="{{@key}}" style="float:left;width:200px;overflow:hidden;font-family:monospace;font-size:13px;font-weight:bold;text-overflow:ellipsis;">{{@key}}</div>
-                        <div class="seq-property-value" style="margin-left:245px;font-family:monospace;font-size:13px;word-wrap:break-word;white-space:pre-wrap;">{{pretty this}}</div>
+                        <div class="seq-property-name" title="{{@key}}" style="float: left; width: 200px; overflow: hidden; font-family: monospace; font-size: 13px; font-weight: bold; text-overflow: ellipsis;">{{@key}}</div>
+                        <div class="seq-property-value" style="margin-left: 245px; font-family: monospace; font-size: 13px; word-wrap: break-word; white-space: pre-wrap;">{{pretty this}}</div>
                     </div>
                     {{/each}}
                     {{#if $Exception}}
-                    <pre class="seq-event-exception" style="padding-top:2px;padding-bottom:2px;padding-right:2px;padding-left:2px;margin-top:5px;overflow:auto;font-family:monospace;font-size:9pt;color:white;white-space:pre;background-color:#e03836;">{{$Exception}}</pre>
+                    <pre class="seq-event-exception" style="padding-top: 2px; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 5px; overflow: auto; font-family: monospace; font-size: 9pt; color: white; white-space: pre; background-color: #e03836;">{{$Exception}}</pre>
                     {{/if}}
                 </div>
             </div>
         </div>
-        <div class="email-footer" style="margin-top:20px;font-size:9pt;font-style:italic;color:#ddd;">
-            Sent from <a href="https://getseq.net" style="text-decoration:none;color:#ddd;font-weight:bold;">Seq</a> &mdash; structured log server for .NET &mdash; installed
-            at <a href='{{{$ServerUri}}}' style="text-decoration:none;color:#ddd;font-weight:bold;">{{$ServerUri}}</a>.
+        <div class="email-footer" style="margin-top: 20px; font-size: 9pt; font-style: italic; color: #ddd;">
+            Sent from <a href="https://getseq.net" style="text-decoration: none; color: #ddd; font-weight: bold;">Seq</a> &mdash; structured log server for .NET &mdash; installed
+            at <a href='{{{$ServerUri}}}' style="text-decoration: none; color: #ddd; font-weight: bold;">{{$ServerUri}}</a>.
         </div>
     </div>
+    {{/each}}
 </body>
 </html>

--- a/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
@@ -126,37 +126,37 @@
     </style>
 </head>
 <body>
-    {{#each Events}}
-    <div class="email-body" style="margin-top: 10px; margin-bottom: 10px; margin-right: 10px; margin-left: 10px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333; background-color: #fff;">
-        <div class="seq-event-detail" style="width: 100%; padding-top: 0; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 2px; margin-bottom: 0; margin-right: -3px; margin-left: -3px; overflow: visible; white-space: nowrap; border-style: solid; border-width: 1px; border-radius: 2px; background-color: #eff9ff; border-color: #54afcc;">
-            <div class="seq-event-tools" style="float: left; margin-right: 5px;">
-                <span class="seq-event-timestamp" title="{{$UtcTimestamp}}" style="margin-right: 5px; color: white;"><span class="datetime" style="display: inline-block; width: 172px; padding-top: 2px; padding-bottom: 2px; padding-right: 4px; padding-left: 4px; font-size: 11.844px; font-weight: bold; line-height: 14px; color: #fff; text-shadow: none; white-space: nowrap; vertical-align: baseline; background-color: #aaa; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 2px; margin-top: 2px;">{{$LocalTimestamp}}</span></span>
-            </div>
-            <div class="seq-event-data" style="margin-top: 2px; margin-left: 190px; overflow: visible; white-space: normal;">
-                <div>
-                    <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
-                </div>
-                <div class="seq-event-actions" style="margin-top: 5px;">
-                    <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action" style="color: #007acc; text-decoration: none; padding-right: 10px; font-size: 12px;">View in Seq</a>
-                </div>
-                <div class="seq-event-properties" style="margin-top: 5px;">
-                    {{#each $Properties}}
-                    <div class="seq-event-property">
-                        <div class="seq-property-name" title="{{@key}}" style="float: left; width: 200px; overflow: hidden; font-family: monospace; font-size: 13px; font-weight: bold; text-overflow: ellipsis;">{{@key}}</div>
-                        <div class="seq-property-value" style="margin-left: 245px; font-family: monospace; font-size: 13px; word-wrap: break-word; white-space: pre-wrap;">{{pretty this}}</div>
-                    </div>
-                    {{/each}}
-                    {{#if $Exception}}
-                    <pre class="seq-event-exception" style="padding-top: 2px; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 5px; overflow: auto; font-family: monospace; font-size: 9pt; color: white; white-space: pre; background-color: #e03836;">{{$Exception}}</pre>
-                    {{/if}}
-                </div>
-            </div>
+<div class="email-body" style="margin-top: 10px; margin-bottom: 10px; margin-right: 10px; margin-left: 10px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333; background-color: #fff;">
+    {{#each $Events}}
+    <div class="seq-event-detail" style="width: 100%; padding-top: 0; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 2px; margin-bottom: 0; margin-right: -3px; margin-left: -3px; overflow: visible; white-space: nowrap; border-style: solid; border-width: 1px; border-radius: 2px; background-color: #eff9ff; border-color: #54afcc;">
+        <div class="seq-event-tools" style="float: left; margin-right: 5px;">
+            <span class="seq-event-timestamp" title="{{$UtcTimestamp}}" style="margin-right: 5px; color: white;"><span class="datetime" style="display: inline-block; width: 172px; padding-top: 2px; padding-bottom: 2px; padding-right: 4px; padding-left: 4px; font-size: 11.844px; font-weight: bold; line-height: 14px; color: #fff; text-shadow: none; white-space: nowrap; vertical-align: baseline; background-color: #aaa; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 2px; margin-top: 2px;">{{$LocalTimestamp}}</span></span>
         </div>
-        <div class="email-footer" style="margin-top: 20px; font-size: 9pt; font-style: italic; color: #ddd;">
-            Sent from <a href="https://getseq.net" style="text-decoration: none; color: #ddd; font-weight: bold;">Seq</a> &mdash; structured log server for .NET &mdash; installed
-            at <a href='{{{$ServerUri}}}' style="text-decoration: none; color: #ddd; font-weight: bold;">{{$ServerUri}}</a>.
+        <div class="seq-event-data" style="margin-top: 2px; margin-left: 190px; overflow: visible; white-space: normal;">
+            <div>
+                <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
+            </div>
+            <div class="seq-event-actions" style="margin-top: 5px;">
+                <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action" style="color: #007acc; text-decoration: none; padding-right: 10px; font-size: 12px;">View in Seq</a>
+            </div>
+            <div class="seq-event-properties" style="margin-top: 5px;">
+                {{#each $Properties}}
+                <div class="seq-event-property">
+                    <div class="seq-property-name" title="{{@key}}" style="float: left; width: 200px; overflow: hidden; font-family: monospace; font-size: 13px; font-weight: bold; text-overflow: ellipsis;">{{@key}}</div>
+                    <div class="seq-property-value" style="margin-left: 245px; font-family: monospace; font-size: 13px; word-wrap: break-word; white-space: pre-wrap;">{{pretty this}}</div>
+                </div>
+                {{/each}}
+                {{#if $Exception}}
+                <pre class="seq-event-exception" style="padding-top: 2px; padding-bottom: 2px; padding-right: 2px; padding-left: 2px; margin-top: 5px; overflow: auto; font-family: monospace; font-size: 9pt; color: white; white-space: pre; background-color: #e03836;">{{$Exception}}</pre>
+                {{/if}}
+            </div>
         </div>
     </div>
     {{/each}}
+    <div class="email-footer" style="margin-top: 20px; font-size: 9pt; font-style: italic; color: #ddd;">
+        Sent from <a href="https://getseq.net" style="text-decoration: none; color: #ddd; font-weight: bold;">Seq</a> &mdash; structured log server for .NET &mdash; installed
+        at <a href='{{{$ServerUri}}}' style="text-decoration: none; color: #ddd; font-weight: bold;">{{$ServerUri}}</a>.
+    </div>
+</div>
 </body>
 </html>

--- a/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <title>[{{$Level}}] {{$Message}} (via Seq)</title>
+    <title>[{{$Events.[0].$Level}}] {{{$Events.[0].$Message}}} (via Seq){{#if $MultipleEvents}} ({{$EventCount}}){{/if}}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <style>
         .email-body {
@@ -129,6 +129,7 @@
     </style>
 </head>
 <body>
+    {{#each $Events}}
     <div class="email-body">
         <div class="seq-event-detail">
             <div class="seq-event-tools">
@@ -158,6 +159,7 @@
             Sent from <a href="https://getseq.net">Seq</a> &mdash; structured log server for .NET &mdash; installed
             at <a href='{{{$ServerUri}}}'>{{$ServerUri}}</a>.
         </div>
-    </div>
+    {{/each}}
+</div>
 </body>
 </html>

--- a/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
@@ -129,37 +129,37 @@
     </style>
 </head>
 <body>
+<div class="email-body">
     {{#each $Events}}
-    <div class="email-body">
-        <div class="seq-event-detail">
-            <div class="seq-event-tools">
-                <span class="seq-event-timestamp" title="{{$UtcTimestamp}}"><span class="datetime">{{$LocalTimestamp}}</span></span>
+    <div class="seq-event-detail">
+        <div class="seq-event-tools">
+            <span class="seq-event-timestamp" title="{{$UtcTimestamp}}"><span class="datetime">{{$LocalTimestamp}}</span></span>
+        </div>
+        <div class="seq-event-data">
+            <div>
+                <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
             </div>
-            <div class="seq-event-data">
-                <div>
-                    <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
+            <div class="seq-event-actions">
+                <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action">View in Seq</a>
+            </div>
+            <div class="seq-event-properties">
+                {{#each $Properties}}
+                <div class="seq-event-property">
+                    <div class="seq-property-name" title="{{@key}}">{{@key}}</div>
+                    <div class="seq-property-value">{{pretty this}}</div>
                 </div>
-                <div class="seq-event-actions">
-                    <a href='{{{$ServerUri}}}#/events?filter=@Id%3D%3D"{{$Id}}"' class="action">View in Seq</a>
-                </div>
-                <div class="seq-event-properties">
-                    {{#each $Properties}}
-                    <div class="seq-event-property">
-                        <div class="seq-property-name" title="{{@key}}">{{@key}}</div>
-                        <div class="seq-property-value">{{pretty this}}</div>
-                    </div>
-                    {{/each}}
-                    {{#if $Exception}}
-                    <pre class="seq-event-exception">{{$Exception}}</pre>
-                    {{/if}}
-                </div>
+                {{/each}}
+                {{#if $Exception}}
+                <pre class="seq-event-exception">{{$Exception}}</pre>
+                {{/if}}
             </div>
         </div>
-        <div class="email-footer">
-            Sent from <a href="https://getseq.net">Seq</a> &mdash; structured log server for .NET &mdash; installed
-            at <a href='{{{$ServerUri}}}'>{{$ServerUri}}</a>.
-        </div>
+    </div>
     {{/each}}
+    <div class="email-footer">
+        Sent from <a href="https://getseq.net">Seq</a> &mdash; structured log server for .NET &mdash; installed
+        at <a href='{{{$ServerUri}}}'>{{$ServerUri}}</a>.
+    </div>
 </div>
 </body>
 </html>

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Handlebars">
-      <HintPath>..\..\packages\Handlebars.Net.1.2.9\lib\Handlebars.dll</HintPath>
+    <Reference Include="Handlebars, Version=1.0.5554.20810, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Handlebars.Net.1.2.10\lib\Handlebars.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -53,6 +54,18 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmailReactor.cs" />

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -68,7 +68,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BatchingStream.cs" />
+    <Compile Include="BatchingStreamFactory.cs" />
+    <Compile Include="EmailFormatter.cs" />
+    <Compile Include="EmailFormatterFactory.cs" />
     <Compile Include="EmailReactor.cs" />
+    <Compile Include="IBatchingStream.cs" />
+    <Compile Include="IBatchingStreamFactory.cs" />
+    <Compile Include="IEmailFormatter.cs" />
+    <Compile Include="IEmailFormatterFactory.cs" />
     <Compile Include="IMailClient.cs" />
     <Compile Include="IMailClientFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -93,6 +101,7 @@
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.nuspec
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.nuspec
@@ -16,6 +16,7 @@
     <file src="bin\Release\Seq.App.EmailPlus.dll" target="lib\net45" />
     <file src="bin\Release\Handlebars.dll" target="lib\net45" />
     <file src="bin\Release\Newtonsoft.Json.dll" target="lib\net45" />
+    <file src="bin\Release\System.Reactive.Core.dll" target="lib\net45" />
     <file src="bin\Release\System.Reactive.Interfaces.dll" target="lib\net45" />
     <file src="bin\Release\System.Reactive.Linq.dll" target="lib\net45" />
     <file src="bin\Release\System.Reactive.PlatformServices.dll" target="lib\net45" />

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.nuspec
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.nuspec
@@ -16,5 +16,8 @@
     <file src="bin\Release\Seq.App.EmailPlus.dll" target="lib\net45" />
     <file src="bin\Release\Handlebars.dll" target="lib\net45" />
     <file src="bin\Release\Newtonsoft.Json.dll" target="lib\net45" />
+    <file src="bin\Release\System.Reactive.Interfaces.dll" target="lib\net45" />
+    <file src="bin\Release\System.Reactive.Linq.dll" target="lib\net45" />
+    <file src="bin\Release\System.Reactive.PlatformServices.dll" target="lib\net45" />
   </files>
 </package>

--- a/src/Seq.App.EmailPlus/SmtpMailClient.cs
+++ b/src/Seq.App.EmailPlus/SmtpMailClient.cs
@@ -5,11 +5,11 @@ namespace Seq.App.EmailPlus
 {
     public class SmtpMailClient : IMailClient
     {
-        private SmtpClient _smtpClient;
+        private readonly SmtpClient _smtpClient;
 
         public SmtpMailClient(string host, int port, bool enableSsl)
         {
-            _smtpClient = new SmtpClient(host, port) { EnableSsl = enableSsl };
+            _smtpClient = new SmtpClient(host, port) {EnableSsl = enableSsl};
         }
 
         public void Dispose()
@@ -19,54 +19,30 @@ namespace Seq.App.EmailPlus
 
         public ICredentialsByHost Credentials
         {
-            get
-            {
-                return _smtpClient.Credentials;
-            }
+            get { return _smtpClient.Credentials; }
 
-            set
-            {
-                _smtpClient.Credentials = value;
-            }
+            set { _smtpClient.Credentials = value; }
         }
 
         public bool EnableSsl
         {
-            get
-            {
-                return _smtpClient.EnableSsl;
-            }
+            get { return _smtpClient.EnableSsl; }
 
-            set
-            {
-                _smtpClient.EnableSsl = value;
-            }
+            set { _smtpClient.EnableSsl = value; }
         }
 
         public string Host
         {
-            get
-            {
-                return _smtpClient.Host;
-            }
+            get { return _smtpClient.Host; }
 
-            set
-            {
-                _smtpClient.Host = value;
-            }
+            set { _smtpClient.Host = value; }
         }
 
         public int Port
         {
-            get
-            {
-                return _smtpClient.Port;
-            }
+            get { return _smtpClient.Port; }
 
-            set
-            {
-                _smtpClient.Port = value;
-            }
+            set { _smtpClient.Port = value; }
         }
 
         public void Send(MailMessage message)

--- a/src/Seq.App.EmailPlus/SmtpMailClient.cs
+++ b/src/Seq.App.EmailPlus/SmtpMailClient.cs
@@ -1,0 +1,77 @@
+﻿using System.Net;
+using System.Net.Mail;
+
+namespace Seq.App.EmailPlus
+{
+    public class SmtpMailClient : IMailClient
+    {
+        private SmtpClient _smtpClient;
+
+        public SmtpMailClient(string host, int port, bool enableSsl)
+        {
+            _smtpClient = new SmtpClient(host, port) { EnableSsl = enableSsl };
+        }
+
+        public void Dispose()
+        {
+            _smtpClient.Dispose();
+        }
+
+        public ICredentialsByHost Credentials
+        {
+            get
+            {
+                return _smtpClient.Credentials;
+            }
+
+            set
+            {
+                _smtpClient.Credentials = value;
+            }
+        }
+
+        public bool EnableSsl
+        {
+            get
+            {
+                return _smtpClient.EnableSsl;
+            }
+
+            set
+            {
+                _smtpClient.EnableSsl = value;
+            }
+        }
+
+        public string Host
+        {
+            get
+            {
+                return _smtpClient.Host;
+            }
+
+            set
+            {
+                _smtpClient.Host = value;
+            }
+        }
+
+        public int Port
+        {
+            get
+            {
+                return _smtpClient.Port;
+            }
+
+            set
+            {
+                _smtpClient.Port = value;
+            }
+        }
+
+        public void Send(MailMessage message)
+        {
+            _smtpClient.Send(message);
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/SmtpMailClientFactory.cs
+++ b/src/Seq.App.EmailPlus/SmtpMailClientFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public class SmtpMailClientFactory : IMailClientFactory
+    {
+        public IMailClient Create(string host, int port, bool enableSsl)
+        {
+            return new SmtpMailClient(host, port, enableSsl);
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/packages.config
+++ b/src/Seq.App.EmailPlus/packages.config
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Handlebars.Net" version="1.2.9" targetFramework="net45" />
+  <package id="Handlebars.Net" version="1.2.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
   <package id="Serilog" version="1.4.113" targetFramework="net45" />
 </packages>

--- a/test/Seq.App.EmailPlus.Tests/BatchingStreamTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/BatchingStreamTests.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using Microsoft.Reactive.Testing;
+using NUnit.Framework;
+
+namespace Seq.App.EmailPlus.Tests
+{
+    [TestFixture]
+    public class BatchingStreamTests
+    {
+        private TestScheduler _scheduler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scheduler = new TestScheduler();
+        }
+
+        [Test]
+        public void NullDelayDisablesBatching()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler);
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results.Count, "The wrong number of batches was returned.");
+        }
+
+        [Test]
+        public void NonBatchedResultsIncludeOneItem()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler);
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            foreach (var list in results)
+                Assert.AreEqual(1, list.Count, "A non-batched result had more than one item.");
+        }
+
+        [Test]
+        public void NonBatchedResultsIncludeCorrectValues()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler);
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("bar"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual("foo", results[0][0], "The value of the first item was incorrect.");
+            Assert.AreEqual("bar", results[1][0], "The value of the second item was incorrect.");
+        }
+
+        [Test]
+        public void ItemsWithDifferentKeysAreNotBatched()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(2));
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("bar"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results.Count, "The wrong number of batches was returned.");
+        }
+
+        [Test]
+        public void BatchedResultsHaveCorrectNumberOfItems()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(2));
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("bar"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("bar"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results[0].Count, "The first batch had the wrong number of items.");
+            Assert.AreEqual(2, results[1].Count, "The second batch had the wrong number of items.");
+        }
+
+        [Test]
+        public void BatchedResultsHaveCorrectValues()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(2));
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("bar"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("bar"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual("foo", results[0][0], "The value of the first item in the first batch was incorrect.");
+            Assert.AreEqual("foo", results[0][1], "The value of the second item in the first batch was incorrect.");
+            Assert.AreEqual("bar", results[1][0], "The value of the first item in the second batch was incorrect.");
+            Assert.AreEqual("bar", results[1][1], "The value of the second item in the second batch was incorrect.");
+        }
+
+        [Test]
+        public void BatchDelayIsHonored()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(1));
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(0), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2.01), () => stream.Add("foo"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results.Count, "The wrong number of batches was returned.");
+            Assert.AreEqual(2, results[0].Count, "The first batch has the wrong number of items.");
+            Assert.AreEqual(1, results[1].Count, "The second batch has the wrong number of items.");
+        }
+
+        [Test]
+        public void MaxDelayIsHonored()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(0), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2.01), () => stream.Add("foo"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results.Count, "The wrong number of batches was returned.");
+            Assert.AreEqual(3, results[0].Count, "The first batch has the wrong number of items.");
+            Assert.AreEqual(1, results[1].Count, "The second batch has the wrong number of items.");
+        }
+
+        [Test]
+        public void MaxSizeIsHonored()
+        {
+            var stream = new BatchingStream<string, string>(value => value, _scheduler, TimeSpan.FromSeconds(2), maxSize: 2);
+
+            _scheduler.Schedule(TimeSpan.FromSeconds(0), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(1), () => stream.Add("foo"));
+            _scheduler.Schedule(TimeSpan.FromSeconds(2), () => stream.Add("foo"));
+
+            var results = new List<IList<string>>();
+            using (stream.Batches.Subscribe(list => results.Add(list)))
+                _scheduler.Start();
+
+            Assert.AreEqual(2, results.Count, "The wrong number of batches was returned.");
+            Assert.AreEqual(2, results[0].Count, "The first batch has the wrong number of items.");
+            Assert.AreEqual(1, results[1].Count, "The second batch has the wrong number of items.");
+        }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+
+namespace Seq.App.EmailPlus.Tests
+{
+    [TestFixture]
+    public class EmailFormatterTests : EventTestsBase
+    {
+        [Test]
+        public void CanHavePropertyInSubject()
+        {
+            var formatter = new EmailFormatter("foo", "bar", subjectTemplate: "[{{$Events.[0].$Properties.Category}}]");
+            var subject = formatter.FormatSubject(new[] {GetLogEvent()});
+            Assert.IsTrue(subject.Contains("Security"), "Subject did not contain the property.");
+        }
+
+        [Test]
+        public void DefaultTemplateBodyContainsAllBatchedEvents()
+        {
+            var formatter = new EmailFormatter("foo", "bar");
+            var body = formatter.FormatBody(new[] {GetLogEvent(), GetLogEvent(1)});
+            Assert.AreEqual(2, CountSubstrings(body, "div class=\"seq-event-detail\""), "Body did not contain the correct number of events.");
+        }
+
+        [Test]
+        public void DefaultTemplateSubjectEndsWithCountOnBatchedEvents()
+        {
+            var formatter = new EmailFormatter("foo", "bar");
+            var subject = formatter.FormatSubject(new[] { GetLogEvent(), GetLogEvent(1) });
+            Assert.IsTrue(subject.EndsWith("(2)"));
+        }
+
+        [Test]
+        public void DefaultTemplateSubjectDoesNotEndWithCountSingleEvents()
+        {
+            var formatter = new EmailFormatter("foo", "bar");
+            var subject = formatter.FormatSubject(new[] { GetLogEvent(), GetLogEvent(1) });
+            Assert.IsFalse(subject.EndsWith("(1)"));
+        }
+
+        [Test]
+        public void MaxSubjectLengthIsEnforced()
+        {
+            var formatter = new EmailFormatter("foo", "bar", maxSubjectLength: 5);
+            var subject = formatter.FormatSubject(new[] { GetLogEvent() });
+            Assert.IsTrue(subject.Length == 5, "Subject was the wrong length.");
+        }
+
+        private static int CountSubstrings(string source, string substring)
+        {
+            return (source.Length - source.Replace(substring, string.Empty).Length) / substring.Length;
+        }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
@@ -25,7 +25,7 @@ namespace Seq.App.EmailPlus.Tests
         public void DefaultTemplateSubjectEndsWithCountOnBatchedEvents()
         {
             var formatter = new EmailFormatter("foo", "bar");
-            var subject = formatter.FormatSubject(new[] { GetLogEvent(), GetLogEvent(1) });
+            var subject = formatter.FormatSubject(new[] {GetLogEvent(), GetLogEvent(1)});
             Assert.IsTrue(subject.EndsWith("(2)"));
         }
 
@@ -33,7 +33,7 @@ namespace Seq.App.EmailPlus.Tests
         public void DefaultTemplateSubjectDoesNotEndWithCountSingleEvents()
         {
             var formatter = new EmailFormatter("foo", "bar");
-            var subject = formatter.FormatSubject(new[] { GetLogEvent(), GetLogEvent(1) });
+            var subject = formatter.FormatSubject(new[] {GetLogEvent(), GetLogEvent(1)});
             Assert.IsFalse(subject.EndsWith("(1)"));
         }
 
@@ -41,7 +41,7 @@ namespace Seq.App.EmailPlus.Tests
         public void MaxSubjectLengthIsEnforced()
         {
             var formatter = new EmailFormatter("foo", "bar", maxSubjectLength: 5);
-            var subject = formatter.FormatSubject(new[] { GetLogEvent() });
+            var subject = formatter.FormatSubject(new[] {GetLogEvent()});
             Assert.IsTrue(subject.Length == 5, "Subject was the wrong length.");
         }
 
@@ -49,13 +49,13 @@ namespace Seq.App.EmailPlus.Tests
         public void FormatsSubjectCorrectlyWhenMaxLengthIsLonger()
         {
             var formatter = new EmailFormatter("foo", "bar", maxSubjectLength: 130);
-            var subject = formatter.FormatSubject(new[] { GetLogEvent() });
+            var subject = formatter.FormatSubject(new[] {GetLogEvent()});
             Assert.IsTrue(subject.EndsWith("(via Seq)"), "Subject was truncated when it should not have been.");
         }
 
         private static int CountSubstrings(string source, string substring)
         {
-            return (source.Length - source.Replace(substring, string.Empty).Length) / substring.Length;
+            return (source.Length - source.Replace(substring, string.Empty).Length)/substring.Length;
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailFormatterTests.cs
@@ -45,6 +45,14 @@ namespace Seq.App.EmailPlus.Tests
             Assert.IsTrue(subject.Length == 5, "Subject was the wrong length.");
         }
 
+        [Test]
+        public void FormatsSubjectCorrectlyWhenMaxLengthIsLonger()
+        {
+            var formatter = new EmailFormatter("foo", "bar", maxSubjectLength: 130);
+            var subject = formatter.FormatSubject(new[] { GetLogEvent() });
+            Assert.IsTrue(subject.EndsWith("(via Seq)"), "Subject was truncated when it should not have been.");
+        }
+
         private static int CountSubstrings(string source, string substring)
         {
             return (source.Length - source.Replace(substring, string.Empty).Length) / substring.Length;

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using Moq;
+using NUnit.Framework;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.EmailPlus.Tests
+{
+    [TestFixture]
+    public class EmailReactorTests
+    {
+        [Test]
+        public void SendsFromCorrectAddress()
+        {
+            var mailClient = new Mock<IMailClient>();
+            mailClient.Setup(mc => mc.Send(It.Is<MailMessage>(mm => mm.From.Address.Equals("baz@qux.com"))))
+                .Verifiable();
+
+            var mailFactory = new Mock<IMailClientFactory>();
+            mailFactory.Setup(mf => mf.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Returns(mailClient.Object)
+                .Verifiable();
+
+            var reactor = GetEmailReactor(mailFactory.Object);
+            reactor.On(LogEvent);
+
+            mailFactory.Verify();
+            mailClient.Verify();
+        }
+
+        [Test]
+        public void SendsToCorrectAddress()
+        {
+            var mailClient = new Mock<IMailClient>();
+            mailClient.Setup(mc => mc.Send(It.Is<MailMessage>(mm => mm.To.Any(a => a.Address.Equals("foo@bar.com")))))
+                .Verifiable();
+
+            var mailFactory = new Mock<IMailClientFactory>();
+            mailFactory.Setup(mf => mf.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Returns(mailClient.Object)
+                .Verifiable();
+
+            var reactor = GetEmailReactor(mailFactory.Object);
+            reactor.On(LogEvent);
+
+            mailFactory.Verify();
+            mailClient.Verify();
+        }
+
+        [Test]
+        public void CanHavePropertyInSubject()
+        {
+            var mailClient = new Mock<IMailClient>();
+            mailClient.Setup(mc => mc.Send(It.Is<MailMessage>(mm => mm.Subject.Equals("[Information] [Security] Test (via Seq)"))))
+                .Verifiable();
+
+            var mailFactory = new Mock<IMailClientFactory>();
+            mailFactory.Setup(mf => mf.Create(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Returns(mailClient.Object)
+                .Verifiable();
+
+            var reactor = GetEmailReactor(mailFactory.Object);
+            reactor.On(LogEvent);
+
+            mailFactory.Verify();
+            mailClient.Verify();
+        }
+
+        private static Event<LogEventData> LogEvent
+        {
+            get
+            {
+                var logEventData = new LogEventData
+                {
+                    Id = "1",
+                    Level = LogEventLevel.Information,
+                    LocalTimestamp = DateTimeOffset.Now,
+                    RenderedMessage = "Test",
+                    Properties = new Dictionary<string, object> { { "Category", "Security" } }
+                };
+                return new Event<LogEventData>(logEventData.Id, 1, DateTime.UtcNow, logEventData);
+            }
+        }
+
+        private static EmailReactor GetEmailReactor(IMailClientFactory mailClientFactory)
+        {
+            var appHost = new Mock<IAppHost>();
+            appHost.SetupGet(h => h.Host).Returns(new Host(new[] { "localhost" }, "test"));
+
+            var reactor = new EmailReactor(mailClientFactory)
+            {
+                From = "baz@qux.com",
+                To = "foo@bar.com",
+                SubjectTemplate = "[{{$Level}}] [{{$Properties.Category}}] {{{$Message}}} (via Seq)"
+            };
+            reactor.Attach(appHost.Object);
+
+            return reactor;
+        }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -150,29 +150,7 @@ namespace Seq.App.EmailPlus.Tests
             Assert.AreEqual(50, actual.Value, "Incorrect max size setting was used.");
         }
 
-        [Test]
-        public void DefaultsToSaneMaxSubjectLength()
-        {
-            var reactor = new EmailReactor();
-            Assert.IsNotNull(reactor.MaxSubjectLength, "Max subject length was not defaulted.");
-            Assert.IsTrue(reactor.MaxSubjectLength.Value > 0, "Default max subject length was negative.");
-        }
-
-        [Test]
-        public void UsesMaxSubjectLength()
-        {
-            var reactor = new EmailReactor {MaxSubjectLength = 123};
-            Assert.AreEqual(123, reactor.MaxSubjectLength);
-        }
-
-        [Test]
-        public void MaxSubjectLengthCanBeDisabled()
-        {
-            var reactor = new EmailReactor {MaxSubjectLength = null};
-            Assert.IsNull(reactor.MaxSubjectLength);
-        }
-
-        private EmailReactor GetEmailReactor(double? delay = null, double? maxDelay = null, int? maxSize = null, int? maxSubjectLength = null)
+        private EmailReactor GetEmailReactor(double? delay = null, double? maxDelay = null, int? maxSize = null)
         {
             var appHost = new Mock<IAppHost>();
             appHost.SetupGet(h => h.Host).Returns(new Host(new[] { "localhost" }, "test"));
@@ -183,8 +161,7 @@ namespace Seq.App.EmailPlus.Tests
                 To = "foo@bar.com",
                 BatchDelay = delay,
                 BatchMaxDelay = maxDelay,
-                BatchMaxAmount = maxSize,
-                MaxSubjectLength = maxSubjectLength
+                BatchMaxAmount = maxSize
             };
             reactor.Attach(appHost.Object);
 

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -89,6 +89,24 @@ namespace Seq.App.EmailPlus.Tests
         }
 
         [Test]
+        public void SendsMessagesAsHtml()
+        {
+            var actual = false;
+
+            _mailClient.Setup(mc => mc.Send(It.IsAny<MailMessage>()))
+                .Callback<MailMessage>(message => actual = message.IsBodyHtml);
+
+            var eventSubject = new Subject<List<Event<LogEventData>>>();
+            _eventStream.SetupGet(es => es.Batches).Returns(eventSubject);
+            _scheduler.Schedule(() => eventSubject.OnNext(new List<Event<LogEventData>> { GetLogEvent() }));
+
+            GetEmailReactor();
+            _scheduler.Start();
+
+            Assert.IsTrue(actual, "Message body was not configured as HTML.");
+        }
+
+        [Test]
         public void AddsEventsToEventStream()
         {
             var @event = GetLogEvent();

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -16,16 +16,14 @@ namespace Seq.App.EmailPlus.Tests
     [TestFixture]
     public class EmailReactorTests : EventTestsBase
     {
-        private TestScheduler _scheduler;
-
-        private Mock<IMailClient> _mailClient;
         private Mock<IEmailFormatter> _emailFormatter;
-        private Mock<IBatchingStream<Event<LogEventData>>> _eventStream;
-
-        private Mock<IMailClientFactory> _mailClientFactory;
         private Mock<IEmailFormatterFactory> _emailFormatterFactory;
-        private Mock<IBatchingStreamFactory<string,Event<LogEventData>>> _eventStreamFactory;
+        private Mock<IBatchingStream<Event<LogEventData>>> _eventStream;
+        private Mock<IBatchingStreamFactory<string, Event<LogEventData>>> _eventStreamFactory;
         private IReturnsResult<IBatchingStreamFactory<string, Event<LogEventData>>> _eventStreamFactorySetup;
+        private Mock<IMailClient> _mailClient;
+        private Mock<IMailClientFactory> _mailClientFactory;
+        private TestScheduler _scheduler;
 
         [SetUp]
         public void SetUp()
@@ -80,7 +78,7 @@ namespace Seq.App.EmailPlus.Tests
 
             var eventSubject = new Subject<List<Event<LogEventData>>>();
             _eventStream.SetupGet(es => es.Batches).Returns(eventSubject);
-            _scheduler.Schedule(() => eventSubject.OnNext(new List<Event<LogEventData>> { GetLogEvent() }));
+            _scheduler.Schedule(() => eventSubject.OnNext(new List<Event<LogEventData>> {GetLogEvent()}));
 
             GetEmailReactor();
             _scheduler.Start();
@@ -98,7 +96,7 @@ namespace Seq.App.EmailPlus.Tests
 
             var eventSubject = new Subject<List<Event<LogEventData>>>();
             _eventStream.SetupGet(es => es.Batches).Returns(eventSubject);
-            _scheduler.Schedule(() => eventSubject.OnNext(new List<Event<LogEventData>> { GetLogEvent() }));
+            _scheduler.Schedule(() => eventSubject.OnNext(new List<Event<LogEventData>> {GetLogEvent()}));
 
             GetEmailReactor();
             _scheduler.Start();
@@ -122,10 +120,7 @@ namespace Seq.App.EmailPlus.Tests
         {
             TimeSpan? actual = null;
             _eventStreamFactorySetup.Callback<Func<Event<LogEventData>, string>, IScheduler, TimeSpan?, TimeSpan?, int?>(
-                (func, scheduler, delay, maxDelay, maxSize) =>
-                {
-                    actual = delay;
-                }).Verifiable();
+                (func, scheduler, delay, maxDelay, maxSize) => { actual = delay; }).Verifiable();
 
             GetEmailReactor(30);
 
@@ -139,10 +134,7 @@ namespace Seq.App.EmailPlus.Tests
         {
             TimeSpan? actual = null;
             _eventStreamFactorySetup.Callback<Func<Event<LogEventData>, string>, IScheduler, TimeSpan?, TimeSpan?, int?>(
-                (func, scheduler, delay, maxDelay, maxSize) =>
-                {
-                    actual = maxDelay;
-                }).Verifiable();
+                (func, scheduler, delay, maxDelay, maxSize) => { actual = maxDelay; }).Verifiable();
 
             GetEmailReactor(maxDelay: 300);
 
@@ -156,10 +148,7 @@ namespace Seq.App.EmailPlus.Tests
         {
             int? actual = null;
             _eventStreamFactorySetup.Callback<Func<Event<LogEventData>, string>, IScheduler, TimeSpan?, TimeSpan?, int?>(
-                (func, scheduler, delay, maxDelay, maxSize) =>
-                {
-                    actual = maxSize;
-                }).Verifiable();
+                (func, scheduler, delay, maxDelay, maxSize) => { actual = maxSize; }).Verifiable();
 
             GetEmailReactor(maxSize: 50);
 
@@ -171,7 +160,7 @@ namespace Seq.App.EmailPlus.Tests
         private EmailReactor GetEmailReactor(double? delay = null, double? maxDelay = null, int? maxSize = null)
         {
             var appHost = new Mock<IAppHost>();
-            appHost.SetupGet(h => h.Host).Returns(new Host(new[] { "localhost" }, "test"));
+            appHost.SetupGet(h => h.Host).Returns(new Host(new[] {"localhost"}, "test"));
 
             var reactor = new EmailReactor(_mailClientFactory.Object, _emailFormatterFactory.Object, _eventStreamFactory.Object, _scheduler)
             {

--- a/test/Seq.App.EmailPlus.Tests/EventTestsBase.cs
+++ b/test/Seq.App.EmailPlus.Tests/EventTestsBase.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.EmailPlus.Tests
+{
+    public class EventTestsBase
+    {
+        protected static Event<LogEventData> GetLogEvent(int id = 0, LogEventLevel level = LogEventLevel.Information)
+        {
+            var logEventData = new LogEventData
+            {
+                Id = id.ToString(),
+                Level = level,
+                LocalTimestamp = DateTimeOffset.Now,
+                RenderedMessage = "Test",
+                Properties = new Dictionary<string, object> { { "Category", "Security" } }
+            };
+            return new Event<LogEventData>(logEventData.Id, 1, DateTime.UtcNow, logEventData);
+        } 
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EventTestsBase.cs
+++ b/test/Seq.App.EmailPlus.Tests/EventTestsBase.cs
@@ -15,9 +15,9 @@ namespace Seq.App.EmailPlus.Tests
                 Level = level,
                 LocalTimestamp = DateTimeOffset.Now,
                 RenderedMessage = "Test",
-                Properties = new Dictionary<string, object> { { "Category", "Security" } }
+                Properties = new Dictionary<string, object> {{"Category", "Security"}}
             };
             return new Event<LogEventData>(logEventData.Id, 1, DateTime.UtcNow, logEventData);
-        } 
+        }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Properties/AssemblyInfo.cs
+++ b/test/Seq.App.EmailPlus.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Seq.App.EmailPlus.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Seq.App.EmailPlus.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4b7ea880-dcde-4074-8d33-83310b8f8f30")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -49,6 +49,18 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Reactive.Testing">
+      <HintPath>..\..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
@@ -68,7 +72,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BatchingStreamTests.cs" />
+    <Compile Include="EmailFormatterTests.cs" />
     <Compile Include="EmailReactorTests.cs" />
+    <Compile Include="EventTestsBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}</ProjectGuid>
+    <ProjectGuid>{756873CC-1042-4D7F-BBE0-8FBD3107F311}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Seq.App.EmailPlus</RootNamespace>
-    <AssemblyName>Seq.App.EmailPlus</AssemblyName>
+    <RootNamespace>Seq.App.EmailPlus.Tests</RootNamespace>
+    <AssemblyName>Seq.App.EmailPlus.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
@@ -32,58 +32,50 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Handlebars">
-      <HintPath>..\..\packages\Handlebars.Net.1.2.9\lib\Handlebars.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Seq.Apps, Version=1.6.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Seq.Apps">
       <HintPath>..\..\packages\Seq.Apps.1.6.4\lib\net45\Seq.Apps.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.4.113\lib\net45\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Serilog.FullNetFx">
       <HintPath>..\..\packages\Serilog.1.4.113\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="EmailReactor.cs" />
-    <Compile Include="IMailClient.cs" />
-    <Compile Include="IMailClientFactory.cs" />
+    <Compile Include="EmailReactorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="SmtpMailClient.cs" />
-    <Compile Include="SmtpMailClientFactory.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
-    <None Include="Seq.App.EmailPlus.nuspec" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Resources\DefaultBodyTemplate.html" />
-    <Content Include="Resources\RawBodyTemplate.html" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+    <ProjectReference Include="..\..\src\Seq.App.EmailPlus\Seq.App.EmailPlus.csproj">
+      <Project>{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9}</Project>
+      <Name>Seq.App.EmailPlus</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Seq.App.EmailPlus.Tests/packages.config
+++ b/test/Seq.App.EmailPlus.Tests/packages.config
@@ -7,6 +7,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Testing" version="2.2.5" targetFramework="net45" />
   <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
   <package id="Serilog" version="1.4.113" targetFramework="net45" />
 </packages>

--- a/test/Seq.App.EmailPlus.Tests/packages.config
+++ b/test/Seq.App.EmailPlus.Tests/packages.config
@@ -2,6 +2,11 @@
 <packages>
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
   <package id="Serilog" version="1.4.113" targetFramework="net45" />
 </packages>

--- a/test/Seq.App.EmailPlus.Tests/packages.config
+++ b/test/Seq.App.EmailPlus.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
+  <package id="Serilog" version="1.4.113" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This is a significant change, and is essentially untested on a real Seq server. I did add unit tests, and it looks ok as far as I can tell, but I will hook it up to a real server and test it out over the next few days. I wanted to go ahead and send a PR now to get some feedback. Not only is it significantly different, but it is also not backwards compatible with templates for previous versions due to having an array of events rather than a single event. For those reasons I was not sure about modifying the existing Email+ app versus creating a new separate app. If you would rather it be a different app, let me know and I'll update this PR.

It should work essentially the same as before with one email per event if you do not configure any of the new settings. If you set a delay, then it will start a batch of events based on the templated subject. As long a new event arrives once every delay period, it will keep waiting and add that event to the batch. Once a full delay period has elapsed, or the max delay or max event count has been reached it will construct an email with the details of each event in the body and send it.

Let me know what you think. I'll post a note here after I'm done testing it out and am confident it is working correctly.