### PR TITLE
Support templates in the EmailPlus TO field

### DIFF
--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Net.Mail;
+
+namespace Seq.App.EmailPlus
+{
+    class DirectMailGateway : IMailGateway
+    {
+        public void Send(SmtpClient client, MailMessage message)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            client.Send(message);
+        }
+    }
+}

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,0 +1,9 @@
+﻿using System.Net.Mail;
+
+namespace Seq.App.EmailPlus
+{
+    interface IMailGateway
+    {
+        void Send(SmtpClient client, MailMessage message);
+    }
+}

--- a/src/Seq.App.EmailPlus/Properties/AssemblyInfo.cs
+++ b/src/Seq.App.EmailPlus/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("Seq.App.EmailPlus.Tests")]
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
@@ -10,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Seq.App.Email")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright © 2014-2019 Datalust and Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -53,8 +53,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DirectMailGateway.cs" />
     <Compile Include="EmailReactor.cs" />
     <Compile Include="HandlebarsHelpers.cs" />
+    <Compile Include="IMailGateway.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
@@ -107,5 +108,25 @@ namespace Seq.App.EmailPlus.Tests
             Assert.Equal("t", result);
         }
 
+
+        [Fact]
+        public void ToAddressesAreTemplated()
+        {
+            var mail = new CollectingMailGateway();
+            var reactor = new EmailReactor(mail)
+            {
+                From = "from@example.com",
+                To = "{{Name}}@example.com",
+                Host = "example.com"
+            };
+
+            reactor.Attach(new TestAppHost());
+
+            var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
+            reactor.On(data);
+
+            var sent = mail.Sent.Single();
+            Assert.Equal("test@example.com", sent.Message.To.ToString());
+        }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -74,7 +74,10 @@
   <ItemGroup>
     <Compile Include="EmailReactorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Support\CollectingMailGateway.cs" />
+    <Compile Include="Support\SentMessage.cs" />
     <Compile Include="Support\Some.cs" />
+    <Compile Include="Support\TestAppHost.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Seq.App.EmailPlus.Tests.Support
+{
+    class CollectingMailGateway : IMailGateway
+    {
+        public List<SentMessage> Sent { get; } = new List<SentMessage>();
+
+        public void Send(SmtpClient client, MailMessage message)
+        {
+            Sent.Add(new SentMessage(client, message));
+        }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
@@ -1,0 +1,16 @@
+﻿using System.Net.Mail;
+
+namespace Seq.App.EmailPlus.Tests.Support
+{
+    class SentMessage
+    {
+        public SmtpClient Client { get; }
+        public MailMessage Message { get; }
+
+        public SentMessage(SmtpClient client, MailMessage message)
+        {
+            Client = client;
+            Message = message;
+        }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/Support/TestAppHost.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/TestAppHost.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Seq.Apps;
+using Serilog;
+
+namespace Seq.App.EmailPlus.Tests.Support
+{
+    class TestAppHost : IAppHost
+    {
+        public Apps.App App { get; } = new Apps.App(new Dictionary<string, string>(), "./storage");
+        public Host Host { get; } = new Host(new [] { "https://seq.example.com" }, null);
+        public ILogger Logger { get; } = new LoggerConfiguration().CreateLogger();
+        public string StoragePath { get; } = "./storage";
+    }
+}


### PR DESCRIPTION
Assuming there's a very low likelihood of existing app configurations using `To` addresses that contain `{{`, this should be a low-risk change. Adds some better testing facilities.

Fixes #58.