### PR TITLE
Use SslOnConnect only for port 465; otherwise, require TLS using STARTTLS

### DIFF
--- a/test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MailKit.Security;
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
@@ -199,6 +200,15 @@ namespace Seq.App.EmailPlus.Tests
 
             var sent = Assert.Single(mail.Sent);
             Assert.Equal(3, sent.Message.To.Count);
+        }
+
+        [Theory]
+        [InlineData(25, SecureSocketOptions.StartTls)]
+        [InlineData(587, SecureSocketOptions.StartTls)]
+        [InlineData(465, SecureSocketOptions.SslOnConnect)]
+        public void CorrectSecureSocketOptionsAreChosenForPort(int port, SecureSocketOptions expected)
+        {
+            Assert.Equal(expected, EmailApp.RequireSslForPort(port));
         }
     }
 }


### PR DESCRIPTION
This ensures that users with working older Email+ configurations again get STARTTLS, and any relying on the newer behavior + port 465 continue working, too.

Fixes #85