### PR TITLE
Change: certificate validation to only fail on invalid certificates

### DIFF
--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
 using MimeKit;
@@ -11,13 +13,26 @@ namespace Seq.App.EmailPlus
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
 
-            var client = new SmtpClient();
-                
+            var client = new SmtpClient
+            {
+                ServerCertificateValidationCallback = ServerCertificateValidation
+            };
+
             await client.ConnectAsync(options.Host, options.Port, options.SocketOptions);
             if (options.RequiresAuthentication)
                 await client.AuthenticateAsync(options.Username, options.Password);
             await client.SendAsync(message);
             await client.DisconnectAsync(true);
+        }
+
+        private static bool ServerCertificateValidation(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors errors)
+        {
+            var cert2 = new X509Certificate2(certificate);
+            return chain.Build(cert2);
         }
     }
 }


### PR DESCRIPTION
Problem:
The default certificate validation method will compare the CN to the host name of the SMTP server and fail validation on a mismatch. This behavior is not common in SMTP clients.

Solution:
Validate the certificate against the certificate chain but not the host name, (ignore the SSL policy errors).