### PR TITLE
Port setting is ignored in versions 3.1.0-dev-00148, 3.1.0-dev-00170, and 3.1.0-dev-00176

### DIFF
--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -106,11 +106,12 @@ namespace Seq.App.EmailPlus
         
         protected override void OnAttached()
         {
+            var port = Port ?? DefaultPort;
             _options = _options = new SmtpOptions(
                 Host,
-                Port ?? DefaultPort,
+                port,
                 EnableSsl ?? false
-                    ? RequireSslForPort(Port ?? DefaultPort)
+                    ? RequireSslForPort(port)
                     : SecureSocketOptions.StartTlsWhenAvailable,
                 Username,
                 Password);


### PR DESCRIPTION
Via @nblumhardt:

> We've identified that this constitutes a vulnerability in versions `3.1.0-dev-00148`, `3.1.0-dev-00170`, and `3.1.0-dev-00176` of the package, available from August 27th 2021 to October 28th 2021.
> 
> The app eagerly computed the `port` value, in the constructor, before the user's `Port` setting would be applied.
> 
> If the user had chosen port 465 to use implicit SSL, and didn't also choose the "Require TLS" setting, this would downgrade the security of their connection by falling back to port 25 with `STARTTLS`.
> 
> We think this is an instance of CWE-693, Protection Mechanism Failure, and have requested a CVE id for it.
>
> The `3.1.0-dev-00179` version of the package properly respects this setting.