### PR TITLE
Update TimeZoneConverter, target .NET 7 explicitly; attempting fix for #105

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -23,7 +23,7 @@ foreach ($src in ls src/*) {
 
     echo "build: Packaging project in $src"
     
-    foreach ($tfm in @("netstandard2.0", "net6.0")) {
+    foreach ($tfm in @("netstandard2.0", "net6.0", "net7.0")) {
         if ($suffix) {
             & dotnet publish -c Release -o "./obj/publish/$tfm" -f $tfm --version-suffix=$suffix
         } else {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.201",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.201",
+    "version": "7.0.200",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Handlebars.Net" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="TimeZoneConverter" Version="5.0.0" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " >

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <VersionPrefix>4.0.1</VersionPrefix>
     <Description>Send HTML email from Seq in response to application log events and alerts. Supports Handlebars template syntax. Requires Seq 5.1+, for earlier Seq versions
     use the 2.x series of releases of this package.</Description>


### PR DESCRIPTION
I haven't been able to reproduce #105 but we've seen a couple of reports, so in lieu of any better options, attempting to flush out the issue with some easy updates.

First, TimeZoneConverter 5.0.0 targets .NET Standard 2.0; this PR updates it to the latest version targeting .NET 6.

Second, while .NET 6 assemblies should practically all run on .NET 7, there's a slight difference between publishing for this at build time, and combining different sets of published assemblies at runtime. Since the `seqcli` host is a set of .NET 7 published assemblies, adding an explicit .NET 7 target to line these up.

If the resulting -dev build successfully fixes the error we can investigate these two changes further; if not, we'll back out the .NET 7 change to save some package space.
 