### PR TITLE
Use .NET 6+ built-in time zone data to avoid other native platform dependencies

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -23,7 +23,7 @@ foreach ($src in ls src/*) {
 
     echo "build: Packaging project in $src"
     
-    foreach ($tfm in @("net6.0")) {
+    foreach ($tfm in @("net6.0", "netstandard2.0")) {
         if ($suffix) {
             & dotnet publish -c Release -o "./obj/publish/$tfm" -f $tfm --version-suffix=$suffix
         } else {

--- a/Build.ps1
+++ b/Build.ps1
@@ -23,7 +23,7 @@ foreach ($src in ls src/*) {
 
     echo "build: Packaging project in $src"
     
-    foreach ($tfm in @("netstandard2.0", "net6.0", "net7.0")) {
+    foreach ($tfm in @("net6.0")) {
         if ($suffix) {
             & dotnet publish -c Release -o "./obj/publish/$tfm" -f $tfm --version-suffix=$suffix
         } else {

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -26,7 +26,6 @@ namespace Seq.App.EmailPlus
         Template? _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
         SmtpOptions? _options;
 
-        public const string UtcTimeZoneName = "Etc/UTC";
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
         const int DefaultPort = 25;
@@ -245,7 +244,7 @@ namespace Seq.App.EmailPlus
                 evt,
                 host,
                 string.IsNullOrEmpty(DateTimeFormat) ? "o" : DateTimeFormat!.Trim(),
-                string.IsNullOrEmpty(TimeZoneName) ? UtcTimeZoneName : TimeZoneName!.Trim());
+                string.IsNullOrEmpty(TimeZoneName) ? PortableTimeZoneInfo.UtcTimeZoneName : TimeZoneName!.Trim());
         }
         
         internal static string TestFormatTemplate(Template template, Event<LogEventData> evt, Host host)

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -26,6 +26,7 @@ namespace Seq.App.EmailPlus
         Template? _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
         SmtpOptions? _options;
 
+        public const string UtcTimeZoneName = "Etc/UTC";
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
         const int DefaultPort = 25;
@@ -108,13 +109,16 @@ namespace Seq.App.EmailPlus
         [SeqAppSetting(
             DisplayName = "Time zone name",
             IsOptional = true,
-            HelpText = "The IANA name of the time zone to use when formatting dates and times. The default is `Etc/UTC`.")]
+            HelpText = "The IANA name of the time zone to use when formatting dates and times. The default is `Etc/UTC`. " +
+                       "On Windows versions before Server 2019, and Seq versions before 2023.1, only Windows time zone " +
+                       "names are accepted.")]
         public string? TimeZoneName { get; set; }
         
         [SeqAppSetting(
             DisplayName = "Date/time format",
             IsOptional = true,
-            HelpText = "A format string controlling how dates and times are formatted. Supports .NET date/time formatting syntax. The default is `o`, producing ISO-8601.")]
+            HelpText = "A format string controlling how dates and times are formatted. Supports .NET date/time formatting " +
+                       "syntax. The default is `o`, producing ISO-8601.")]
         public string? DateTimeFormat { get; set; }
         
         protected override void OnAttached()
@@ -241,7 +245,7 @@ namespace Seq.App.EmailPlus
                 evt,
                 host,
                 string.IsNullOrEmpty(DateTimeFormat) ? "o" : DateTimeFormat!.Trim(),
-                string.IsNullOrEmpty(TimeZoneName) ? "Etc/UTC" : TimeZoneName!.Trim());
+                string.IsNullOrEmpty(TimeZoneName) ? UtcTimeZoneName : TimeZoneName!.Trim());
         }
         
         internal static string TestFormatTemplate(Template template, Event<LogEventData> evt, Host host)

--- a/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
+++ b/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
@@ -149,17 +149,7 @@ namespace Seq.App.EmailPlus
 
             if (arguments.Length >= 3 && arguments[2] is string timeZoneId)
             {
-                TimeZoneInfo tzi;
-                if (IsUsingNlsOnWindows() && timeZoneId == EmailApp.UtcTimeZoneName)
-                {
-                    // Etc/UTC is the default; this keeps the default template working even without ICU.
-                    tzi = TimeZoneInfo.Utc;
-                }
-                else
-                {
-                    tzi = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
-                }
-                
+                var tzi = PortableTimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
                 dt = TimeZoneInfo.ConvertTime(dt, tzi);
             }
 
@@ -170,24 +160,6 @@ namespace Seq.App.EmailPlus
             }
 
             return dt.ToString(format);
-        }
-        
-        static bool IsUsingNlsOnWindows()
-        {
-            // Whether ICU is used on Windows depends on both the Windows version and the .NET version. When ICU is
-            // unavailable, .NET falls back to NLS, which is only aware of Windows time zone names.
-            // See: https://github.com/dotnet/docs/issues/30319
-            
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return false;
-            
-            // https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
-            var sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
-            var bytes = sortVersion.SortId.ToByteArray();
-            var version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
-            var isIcu = version != 0 && version == sortVersion.FullVersion;
-
-            return !isIcu;
         }
     }
 }

--- a/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
+++ b/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using HandlebarsDotNet;
 using Newtonsoft.Json;
-using TimeZoneConverter;
 
 namespace Seq.App.EmailPlus
 {
@@ -149,7 +148,7 @@ namespace Seq.App.EmailPlus
 
             if (arguments.Length >= 3 && arguments[2] is string timeZoneId)
             {
-                var tzi = TZConvert.GetTimeZoneInfo(timeZoneId);
+                var tzi = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
                 dt = TimeZoneInfo.ConvertTime(dt, tzi);
             }
 

--- a/src/Seq.App.EmailPlus/PortableTimeZoneInfo.cs
+++ b/src/Seq.App.EmailPlus/PortableTimeZoneInfo.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Seq.App.EmailPlus;
+
+static class PortableTimeZoneInfo
+{
+    public const string UtcTimeZoneName = "Etc/UTC";
+    
+    public static bool IsUsingNlsOnWindows()
+    {
+        // Whether ICU is used on Windows depends on both the Windows version and the .NET version. When ICU is
+        // unavailable, .NET falls back to NLS, which is only aware of Windows time zone names.
+        // See: https://github.com/dotnet/docs/issues/30319
+            
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return false;
+            
+        // https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
+        var sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
+        var bytes = sortVersion.SortId.ToByteArray();
+        var version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+        var isIcu = version != 0 && version == sortVersion.FullVersion;
+
+        return !isIcu;
+    }
+
+    public static TimeZoneInfo FindSystemTimeZoneById(string timeZoneId)
+    {
+        if (IsUsingNlsOnWindows() && timeZoneId == UtcTimeZoneName)
+        {
+            // Etc/UTC is the default; this keeps the default template working even without ICU.
+            return TimeZoneInfo.Utc;
+        }
+        
+        return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+    }
+}

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
-    <VersionPrefix>4.0.1</VersionPrefix>
-    <Description>Send HTML email from Seq in response to application log events and alerts. Supports Handlebars template syntax. Requires Seq 5.1+, for earlier Seq versions
-    use the 2.x series of releases of this package.</Description>
+    <TargetFramework>net6.0</TargetFramework>
+    <VersionPrefix>5.0.0</VersionPrefix>
+    <Description>Send HTML email from Seq in response to application log events and alerts. Supports Handlebars template syntax.
+      Requires Seq 2022.1+, for earlier Seq versions use the earlier versions of this package.</Description>
     <Authors>Datalust and Contributors</Authors>
     <PackageTags>seq-app</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
@@ -18,18 +18,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.14.0" />
-    <PackageReference Include="Seq.Apps" Version="5.1.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Handlebars.Net" Version="2.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
+    <PackageReference Include="MailKit" Version="3.6.0" />
+    <PackageReference Include="Seq.Apps" Version="2021.4.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " >
-    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="./icon.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="../../LICENSE" Pack="true" PackagePath="" />

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Description>Send HTML email from Seq in response to application log events and alerts. Supports Handlebars template syntax.
       Requires Seq 2022.1+, for earlier Seq versions use the earlier versions of this package.</Description>

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Description>Send HTML email from Seq in response to application log events and alerts. Supports Handlebars template syntax.
-      Requires Seq 2022.1+, for earlier Seq versions use the earlier versions of this package.</Description>
+      Requires Seq 2022.1+, for earlier Seq releases, use the earlier versions of this package.</Description>
     <Authors>Datalust and Contributors</Authors>
     <PackageTags>seq-app</PackageTags>
     <PackageIcon>icon.png</PackageIcon>

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
+++ b/test/Seq.App.EmailPlus.Tests/Seq.App.EmailPlus.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
(Edited)

This fixes https://github.com/datalust/seq-app-htmlemail/issues/105.

The problem causing that failure appears to be that `GZipStream` having platform and architecture-specific dependencies that the managed Seq app packaging mechanism (using `Seq.Apps.dll` and `seqcli` host) can't account for.

This PR moves from TimeZoneConverter (thanks Matt Johnson-Pint!) to .NET 6's built-in time zone data (thanks also Matt Johnson-Pint 😁), which should be correctly deployed thanks to the architecture-specific `seqcli` host distribution.

This will lift the minimum Seq version supported by this package up to 2022.1, which should cover the majority of actively-maintained Seq servers out there. The 4.0.0 app version will remain available for Seq 5.1+ compatibility.

When running on Seq 2022.1, `DateTimeHelper` will now accept Windows time zone names only when running on Windows, and IANA names on Linux. **Breaking change** for some Seq 2022.1 users of this app.

On Seq 2023.1 and later, `DateTimeHelper` will accept both Windows and IANA time zone names on Windows Server 2019 and later (so upgrading Seq won't break email templates set up with this app version). **Breaking change** for some Seq 2022.1 and 2023.1 users of this app.

Bumps major version to 5.0.0, because some users _not_ broken by the problems in 4.0.0 may be relying on IANA time zone names on Seq/Windows versions that won't support them after the update.